### PR TITLE
No path append

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,1 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Sep 23 15:18:54 2016
-
-@author: Peter
-"""
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Sep 23 15:18:54 2016
+
+@author: Peter
+"""
+

--- a/components/disk.py
+++ b/components/disk.py
@@ -6,7 +6,7 @@ Created on Fri Jul 01 12:57:36 2016
 """
 
 from gdsCAD import *
-from components import *
+from PMAT_PDK.components import *
 import os
 print(os.getcwd())
 

--- a/components/ring.py
+++ b/components/ring.py
@@ -6,7 +6,7 @@ Created on Fri Jul 01 12:57:36 2016
 """
 
 from gdsCAD import *
-from components import *
+from PMAT_PDK.components import *
 import os
 print(os.getcwd())
 

--- a/components/wrapped_disk.py
+++ b/components/wrapped_disk.py
@@ -7,7 +7,7 @@ Created on Fri Jul 01 12:57:36 2016
 
 from gdsCAD import *
 import os
-from components import *
+from PMAT_PDK.components import *
 print(os.getcwd())
 
 """Defines a wrapped disk object.  To use, instantiate the 'cell' property."""

--- a/components/wrapped_ring.py
+++ b/components/wrapped_ring.py
@@ -6,7 +6,7 @@ Created on Fri Jul 01 11:54:57 2016
 """
 
 from gdsCAD import *
-from components import *
+from PMAT_PDK.components import *
 import os
 print(os.getcwd())
 

--- a/examples/disk_array.py
+++ b/examples/disk_array.py
@@ -6,10 +6,9 @@ Created on Mon Aug 01 14:26:53 2016
 """
 
 import os.path
-import sys
-sys.path.append('C:\\Users\\dkita\\Dropbox (MIT)\\Research\\gdsCAD\\PMAT-PDK') # ADD MIR PDK LIBRARY TO PYTHON PATH
-from components import *
-import PDKtoolkit as tk
+
+from PMAT_PDK.components import *
+from PMAT_PDK import PDKtoolkit as tk
 from gdsCAD import *
 
 """ Create a top cell """

--- a/examples/mach_zehnder_example.py
+++ b/examples/mach_zehnder_example.py
@@ -6,10 +6,9 @@ Created on Tue Jul 05 17:19:22 2016
 """
 
 import os.path
-import sys
-sys.path.append('C:\\Users\\dkita\\Dropbox (MIT)\\Research\\gdsCAD\\PMAT-PDK') # ADD PDK LIBRARY TO PYTHON PATH
-from components import *
-import PDKtoolkit as tk
+
+from PMAT_PDK.components import *
+from PMAT_PDK import PDKtoolkit as tk
 from gdsCAD import *
 
 """ Create a top cell """

--- a/examples/random_template.py
+++ b/examples/random_template.py
@@ -6,10 +6,9 @@ Created on Fri Jul 01 13:06:48 2016
 """
 
 import os.path
-import sys
-sys.path.append('C:\\Users\\dkita\\Dropbox (MIT)\\Research\\gdsCAD\\PMAT-PDK') # ADD PDK LIBRARY TO PYTHON PATH
-import PDKtoolkit as tk
-from components import *
+
+from PMAT_PDK import PDKtoolkit as tk
+from PMAT_PDK.components import *
 from gdsCAD import *
 
 """ Create a top cell """


### PR DESCRIPTION
This set of commits would change the way that the PDK is called by making the root PMAT_PDK folder a module and the components folder a submodule. By copying the root folder into the site-packages (or equivalent) directory of the python distribution, PMAT_PDK can be referenced without the need to add a sys.path.append at the top of every file.

This would require changing the name of the root folder (and therefore this repository if you want cloning to be easy) to PMAT_PDK instead of PMAT-PDK (since for some reason, the hyphen isn't acceptable as part of a module name to python...).